### PR TITLE
Update tabris dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "tabris-js-remote": "^3.17.0",
-    "tabris": "~3.9.0",
-    "tabris-decorators": "~3.9.0"
+    "tabris": "3.9.0-dev.20241219",
+    "tabris-decorators": "3.9.0-dev.20230522"
   },
   "devDependencies": {
     "@types/node": "^8.0.44",


### PR DESCRIPTION
3.9.0 as of today does not produce an IPA that is accepted by App Store Connect. Minimum deployment target is too low.

To make a new release we need to bump that. Since there was no release since 3.9.0 we need to use a nightly version here.

Additionall context on the new app release:

> App Store Improvement Notice
>
> In 2016, we implemented an ongoing process of evaluating and removing
> apps that no longer function as intended, don’t follow current review
> guidelines, or are outdated. This helps us improve discoverability of
> apps on the App Store, while ensuring that apps work for the majority of
> users and support our latest innovations in security and privacy.
>
> Per App Review Guideline 4, you must "update your app to ensure it
> remains functional and engaging to new and existing customers. Apps that
> stop working or offer a degraded experience may be removed from the App
> Store at any time." For more information on this and other requirements,
> see the App Review Guidelines.