### PR TITLE
Use `prepare-for-signing-action` in iOS workflow

### DIFF
--- a/.github/workflows/ios-app-build.yaml
+++ b/.github/workflows/ios-app-build.yaml
@@ -12,37 +12,20 @@ jobs:
   build-ios:
     runs-on: macos-latest
     name: Build iOS application
-    environment: 'iOS app signing'
+    environment: 'es-fastlane-match'
     steps:
 
       - name: Install the Apple certificate and provisioning profile
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ github.event.inputs.build_type == 'release' && secrets.RELEASE_BUILD_CERTIFICATE_BASE64 || secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{  github.event.inputs.build_type == 'release' && secrets.RELEASE_BUILD_PROVISION_PROFILE_BASE64 || secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          # create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-
-          # import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode --output $CERTIFICATE_PATH
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode --output $PP_PATH
-
-          # create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          # apply provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+        uses: eclipsesource/prepare-for-signing-action@v1
+        with:
+          app_identifier: 'com.eclipsesource.tabris.remote'
+          profile_type: ${{ github.event.inputs.build_type == 'release' && 'appstore' || 'development' }}
+          match_git_url: ${{ vars.TABRIS_IOS_MATCH_GIT_URL }}
+          match_git_branch: ${{ vars.TABRIS_IOS_MATCH_GIT_BRANCH }}
+          match_git_ssh_key: ${{ secrets.TABRIS_IOS_MATCH_GIT_SSH_KEY }}
+          match_password: ${{ secrets.TABRIS_IOS_MATCH_PASSWORD }}
+          fastlane_team_id: ${{ vars.TABRIS_IOS_FASTLANE_TEAM_ID }}
+          fastlane_user: ${{ vars.TABRIS_IOS_FASTLANE_USER }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -81,9 +64,3 @@ jobs:
           name: artifacts.tar
           path: artifacts.tar
           retention-days: 30
-
-      - name: Cleanup
-        if: always()
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
-          rm ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision


### PR DESCRIPTION
It's going to simplify build job maintenance in the future. Code that prepares the environment for signing is replaced by our https://github.com/eclipsesource/prepare-for-signing-action action.