### PR TITLE
Add `Upload to AppStoreConnect` step in iOS workflow

### DIFF
--- a/.github/workflows/ios-app-build.yaml
+++ b/.github/workflows/ios-app-build.yaml
@@ -64,3 +64,14 @@ jobs:
           name: artifacts.tar
           path: artifacts.tar
           retention-days: 30
+
+      - name: AppStore Upload
+        if: ${{ github.event.inputs.build_type == 'release' }}
+        env:
+          FASTLANE_USER: ${{ vars.TABRIS_IOS_FASTLANE_USER }}
+          FASTLANE_APP_SPECIFIC_PASSWORD: ${{ secrets.TABRIS_IOS_FASTLANE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          xcrun altool --upload-app --type ios \
+            --file "$(find ./artifacts/ -iname "*.ipa")" \
+            --username $FASTLANE_USER \
+            --password '@env:FASTLANE_APP_SPECIFIC_PASSWORD'

--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget
   id="com.eclipsesource.tabris.remote"
-  version="3.17.0"
+  version="3.17.1"
   xmlns:android="http://schemas.android.com/apk/res/android"
   android-versionCode="$BUILD_NUMBER"
   ios-CFBundleVersion="$BUILD_NUMBER">


### PR DESCRIPTION
All release builds will be automatically submitted to Testflight. First one v3.17.1 was built here: https://github.com/eclipsesource/tabris-remote-app/actions/runs/12545447797